### PR TITLE
Add environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: dat490-env
+channels:
+  - defaults
+dependencies:
+  - matplotlib=3.5.1
+  - numpy=1.26.2
+  - pandas=1.4.2
+  - python=3.9.12
+  - seaborn=0.11.2
+  - scikit-learn=1.0.2


### PR DESCRIPTION
## Overview
We might have used Anaconda in some classes, so I set up the Python environment using Anaconda.
The primary goal of unifying the versions of Python and each package is to avoid potential errors that can arise from version mismatches.
If you're using Anaconda in a group, consider using this file as a reference for your repo!
Feel free to customize the packages and versions as needed.

## How to use
```
$ cd DAT490_Sandbox
$ conda env create -f environment.yml
$ conda activate dat490-env
$ jupyter notebook
```